### PR TITLE
Fix rittal multi sensor detection

### DIFF
--- a/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
+++ b/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
@@ -202,4 +202,4 @@ foreach ($cmc_iii_sensors as $sensor_id => $sensor_data) {
     discover_sensor(null, $sensor_data['type'], $device, $sensor_data['oid'], $sensor_id, $sensor_data['name'], $sensor_data['desc'], $sensor_data['divisor'] ?? 1, $sensor_data['multiplier'] ?? 1, $sensor_data['low_limit'] ?? null, $sensor_data['low_warn_limit'] ?? null, $sensor_data['warn_limit'] ?? null, $sensor_data['high_limit'] ?? null, $sensor_data['value']);
 }
 
-unset($cmc_iii_var_table, $cmc_iii_sensors, $index, $entry, $var_name_parts, $sensor_name, $var_type, $sensor_id, $sensor_logic, $unit, $type, $sensor_data, $serial_number);
+unset($cmc_iii_var_table, $cmc_iii_sensors, $last_index_prefix, $current_index_prefix, $index, $entry, $var_name_parts, $sensor_name, $var_type, $sensor_id, $sensor_logic, $unit, $type, $sensor_data, $serial_number);

--- a/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
+++ b/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
@@ -27,6 +27,7 @@ use LibreNMS\Util\StringHelpers;
 
 $cmc_iii_var_table = snmpwalk_cache_oid($device, 'cmcIIIVarTable', [], 'RITTAL-CMC-III-MIB', null);
 $cmc_iii_sensors = [];
+$last_index_prefix = $current_index_prefix = "";
 
 foreach ($cmc_iii_var_table as $index => $entry) {
     $var_name_parts = explode('.', $entry['cmcIIIVarName']);
@@ -35,7 +36,10 @@ foreach ($cmc_iii_var_table as $index => $entry) {
     $var_type = $entry['cmcIIIVarType'];
     $sensor_id = count($cmc_iii_sensors);
 
-    if ($cmc_iii_sensors[$sensor_id]['name'] != $sensor_name) {
+    $index_r = explode('.', $index);
+    if( count($index_r) > 1 ) $current_index_prefix = $index_r[0];
+
+    if ($cmc_iii_sensors[$sensor_id]['name'] != $sensor_name || $last_index_prefix != $current_index_prefix ) {
         if ($sensor_id == 0) {
             $sensor_id = 1;
         } else {
@@ -44,6 +48,8 @@ foreach ($cmc_iii_var_table as $index => $entry) {
 
         $cmc_iii_sensors[$sensor_id]['name'] = $sensor_name;
         $cmc_iii_sensors[$sensor_id]['desc'] = $entry['cmcIIIVarValueStr'] ?: $sensor_name;
+
+        $last_index_prefix = $current_index_prefix;
     }
 
     switch ($var_type) {


### PR DESCRIPTION
This patch fixes the detection of multible door sensors with the same Name.

below, you see parts of the parsed snmp result, comming from "snmpwalk_cache_oid"

```
    [5.1] => Array
        (
            [cmcIIIVarName] => Access.DescName
            [cmcIIIVarType] => description
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => string
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => regexp: ^([-_ a-zA-Z0-9]{0,20})$
            [cmcIIIVarSteps] => 0
            [cmcIIIVarValueStr] => Door
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 25609814
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [5.2] => Array
        (
            [cmcIIIVarName] => Access.Value
            [cmcIIIVarType] => value
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 1, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 0
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 44848730
            [cmcIIIVarAccess] => readonly
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 401001
        )

    [5.3] => Array
        (
            [cmcIIIVarName] => Access.Sensitivity
            [cmcIIIVarType] => sensitivity
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 3, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 2
            [cmcIIIVarValueInt] => 2
            [cmcIIIVarLastChange] => 25609814
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [5.4] => Array
        (
            [cmcIIIVarName] => Access.Delay
            [cmcIIIVarType] => outputdelay
            [cmcIIIVarUnit] => s
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 120, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 10 s
            [cmcIIIVarValueInt] => 10
            [cmcIIIVarLastChange] => 25609814
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [5.5] => Array
        (
            [cmcIIIVarName] => Access.Status
            [cmcIIIVarType] => status
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => enum
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => enum: 1,12,13
            [cmcIIIVarSteps] => 0
            [cmcIIIVarValueStr] => Closed
            [cmcIIIVarValueInt] => 13
            [cmcIIIVarLastChange] => 44848738
            [cmcIIIVarAccess] => readonly
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [5.6] => Array
        (
            [cmcIIIVarName] => Access.Category
            [cmcIIIVarType] => category
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => integer: min 0, max 255, scale none, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 0
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 25609814
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [6.1] => Array
        (
            [cmcIIIVarName] => Access.DescName
            [cmcIIIVarType] => description
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => string
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => regexp: ^([-_ a-zA-Z0-9]{0,20})$
            [cmcIIIVarSteps] => 0
            [cmcIIIVarValueStr] => Door
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 25609815
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [6.2] => Array
        (
            [cmcIIIVarName] => Access.Value
            [cmcIIIVarType] => value
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 1, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 0
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 37901652
            [cmcIIIVarAccess] => readonly
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 501001
        )

    [6.3] => Array
        (
            [cmcIIIVarName] => Access.Sensitivity
            [cmcIIIVarType] => sensitivity
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 3, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 2
            [cmcIIIVarValueInt] => 2
            [cmcIIIVarLastChange] => 25609815
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [6.4] => Array
        (
            [cmcIIIVarName] => Access.Delay
            [cmcIIIVarType] => outputdelay
            [cmcIIIVarUnit] => s
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 120, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 10 s
            [cmcIIIVarValueInt] => 10
            [cmcIIIVarLastChange] => 25609815
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [6.5] => Array
        (
            [cmcIIIVarName] => Access.Status
            [cmcIIIVarType] => status
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => enum
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => enum: 1,12,13
            [cmcIIIVarSteps] => 0
            [cmcIIIVarValueStr] => Closed
            [cmcIIIVarValueInt] => 13
            [cmcIIIVarLastChange] => 37901656
            [cmcIIIVarAccess] => readonly
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [6.6] => Array
        (
            [cmcIIIVarName] => Access.Category
            [cmcIIIVarType] => category
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => integer: min 0, max 255, scale none, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 0
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 25609815
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [7.1] => Array
        (
            [cmcIIIVarName] => Access.DescName
            [cmcIIIVarType] => description
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => string
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => regexp: ^([-_ a-zA-Z0-9]{0,20})$
            [cmcIIIVarSteps] => 0
            [cmcIIIVarValueStr] => Door
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 25609816
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [7.2] => Array
        (
            [cmcIIIVarName] => Access.Value
            [cmcIIIVarType] => value
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 1, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 0
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 37901645
            [cmcIIIVarAccess] => readonly
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 601001
        )

    [7.3] => Array
        (
            [cmcIIIVarName] => Access.Sensitivity
            [cmcIIIVarType] => sensitivity
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 3, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 2
            [cmcIIIVarValueInt] => 2
            [cmcIIIVarLastChange] => 25609816
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [7.4] => Array
        (
            [cmcIIIVarName] => Access.Delay
            [cmcIIIVarType] => outputdelay
            [cmcIIIVarUnit] => s
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 1
            [cmcIIIVarConstraints] => integer: min 0, max 120, scale *1, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 10 s
            [cmcIIIVarValueInt] => 10
            [cmcIIIVarLastChange] => 25609816
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [7.5] => Array
        (
            [cmcIIIVarName] => Access.Status
            [cmcIIIVarType] => status
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => enum
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => enum: 1,12,13
            [cmcIIIVarSteps] => 0
            [cmcIIIVarValueStr] => Closed
            [cmcIIIVarValueInt] => 13
            [cmcIIIVarLastChange] => 37901649
            [cmcIIIVarAccess] => readonly
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
        )

    [7.6] => Array
        (
            [cmcIIIVarName] => Access.Category
            [cmcIIIVarType] => category
            [cmcIIIVarUnit] => 
            [cmcIIIVarDataType] => int
            [cmcIIIVarScale] => 0
            [cmcIIIVarConstraints] => integer: min 0, max 255, scale none, step 1
            [cmcIIIVarSteps] => 1
            [cmcIIIVarValueStr] => 0
            [cmcIIIVarValueInt] => 0
            [cmcIIIVarLastChange] => 25609816
            [cmcIIIVarAccess] => readwrite
            [cmcIIIVarQuality] => ok
            [cmcIIIVarEntPhysicalIndex] => 0
```